### PR TITLE
REF: Don't warn on inaccessible source of builtins (#258)

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -258,7 +258,10 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
             _ = inspect.findsource(doc_obj.obj)
             tree = ast.parse(doc_obj.source)  # type: ignore
         except (OSError, TypeError, SyntaxError) as exc:
-            warn("Couldn't read PEP-224 variable docstrings from {!r}: {}".format(doc_obj, exc))
+            # Don't emit a warning for builtins that don't have source available
+            is_builtin = getattr(doc_obj.obj, '__module__', None) == 'builtins'
+            if not is_builtin:
+                warn("Couldn't read PEP-224 variable docstrings from {!r}: {}".format(doc_obj, exc))
             return {}, {}
 
         if isinstance(doc_obj, Class):


### PR DESCRIPTION
* feat: Avoid trying to extract PEP-224 docstrings from builtins.

If a module or a class is a builtins (e.g. from an extension), the
`_pep224_docstrings` function will generate a lot of warnings. This
patch skips the extraction of the PEP-224 docstrings for builtins
modules or classes.

* feat: Extract PEP-224 for builtins, but do not warn if none.

* Fix 'builtins' determination logic

`type(any_class) == type` and its `__module__` is always `'builtins'`

Co-authored-by: Kernc <kerncece@gmail.com>